### PR TITLE
🖼 ⚡ Dynamic Windows canvas size inside "build.py"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+### Changed
+
+- `Makefile` build commands re-arrange with groups
+
 ## [Bibata v1.1.1] - 26 Mar 2021
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Makefile` build commands re-arrange with groups
+- Dynamic determine **Windows canvas size** on **Windows cursor size** inside build.py`
 
 ## [Bibata v1.1.1] - 26 Mar 2021
 

--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,46 @@
 all: clean render build
 
+.PHONY: all
+
+# Default
+clean:
+	@rm -rf bitmaps themes
+
+render: bitmapper svg
+	@cd bitmapper && make install render_modern render_original
+
+build: bitmaps
+	@cd builder && make setup build clean
+
+
+# Specific platform build
 unix: clean render bitmaps
 	@cd builder && make setup build_unix
 
 windows: clean render bitmaps
 	@cd builder && make setup build_windows
 
-.PHONY: all
-
-clean:
-	@rm -rf bitmaps themes
-	
+# Bibata Modern
 modern: clean render_modern build_modern
-original:clean render_original build_original
-
-#
-# Render Bibata Bitmaps
-#
-
-render: bitmapper svg
-	@cd bitmapper && make install render_modern render_original
-
-render_original: bitmapper svg
-	@cd bitmapper && make install render_original
 
 render_modern: bitmapper svg
 	@cd bitmapper && make install render_modern
 
-#
-# Build Bibata Unix & Windows cursors
-#
-
-build: bitmaps
-	@cd builder && make setup build clean
-
-build_unix: bitmaps
-	@rm -rf themes
-	@cd builder && make setup build_unix clean
-
-build_windows: bitmaps
-	@rm -rf themes
-	@cd builder && make setup build_windows clean
-
 build_modern: bitmaps
 	@cd builder && make setup build_modern clean
+
+
+# Bibata Original
+original:clean render_original build_original
+
+render_original: bitmapper svg
+	@cd bitmapper && make install render_original
 
 build_original: bitmaps
 	@cd builder && make setup build_original clean
 
-#
-# Installation
-#
 
+# Installation
 .ONESHELL:
 SHELL:=/bin/bash
 

--- a/builder/bbpkg/configure.py
+++ b/builder/bbpkg/configure.py
@@ -82,12 +82,6 @@ def get_config(bitmaps_dir: Union[str, Path], **kwargs) -> Dict[str, Any]:
             canvas_size = win_data.get("canvas_size", w_canvas_size)
             win_size = win_data.get("size", w_size)
 
-            # Because provided cursor size is bigger than cursor's canvas.
-            # Also, "position" settings will not effect on cursor because the
-            # cursor's canvas and cursor sizes are equals.
-            if (win_size[0] > canvas_size[0]) | (win_size[1] > canvas_size[1]):
-                canvas_size = win_size
-
             config[key] = {
                 **data,
                 "win_key": win_key,

--- a/builder/build.py
+++ b/builder/build.py
@@ -94,7 +94,8 @@ parser.add_argument(
 # Preparing build
 args = parser.parse_args()
 
-bitmaps_dir = Path(args.png_dir).absolute()
+bitmaps_dir = Path(args.png_dir)
+
 name = bitmaps_dir.stem
 comments = {
     "Bibata-Modern-Classic": "Dark & Rounded-edge Bibata",
@@ -104,21 +105,26 @@ comments = {
     "Bibata-Modern-Ice": "Light & Rounded-edge Bibata",
     "Bibata-Original-Ice": "Light & Sharp-edge Bibata",
 }
+info = Info(name=name, comment=comments.get(name, f"{name} Cursors"))
 
 
 x_out_dir = Path(args.out_dir) / name
 win_out_dir = Path(args.out_dir) / f"{name}-Windows"
 
-print(f"Getting '{name}' bitmaps ready for build...")
+# Windows Canvas & Cursor sizes
+win_size: int = args.win_size
+win_canvas_size: int = args.win_canvas_size
+if win_canvas_size < win_size:
+    win_canvas_size = win_size
 
+
+print(f"Getting '{name}' bitmaps ready for build...")
 config = get_config(
     bitmaps_dir,
     x_sizes=args.xsizes,
-    win_canvas_size=args.win_canvas_size,
-    win_size=args.win_size,
+    win_canvas_size=win_canvas_size,
+    win_size=win_size,
 )
-
-info = Info(name=name, comment=comments.get(name, f"{name} Cursors"))
 
 if args.platform == "unix":
     xbuild(config, x_out_dir, info)


### PR DESCRIPTION
## What kind of change does this PR introduce?
`win_canvas_size` parameter dynamically set inside "build.py", if `win_size` parameter is bigger than Windows cursor canvas.

## What is the current behavior?


## What is the new behavior?
Rather than setting `canvas size` inside the `config` function, Do it in `build.py` where the actual parameter passed.

## What steps did you take to test this?

1. Generated Multiple dimension windows cursors
2. Pass the `WIN_SIZE=68` parameter to `make` commands and check generated windows cursors.

## Checklist
- [x] Documentation
- [x] Testing
- [ ] Ready to be merged
- [ ] Added myself to contributors table

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
