### PR TITLE
Fix `None` value warning in `builder/symlinks.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Github Action renamed to `build`
 - prettier `bitmapping` logs
 - `svg/link.py` file added inside pyright config
+- Fix `None` value warning in `builder/symlinks.py`
 
 ## [Bibata v1.1.2] - 12 Jul 2021
 

--- a/builder/src/symlinks.py
+++ b/builder/src/symlinks.py
@@ -178,6 +178,6 @@ def add_missing_xcursor(directory: Union[str, Path]) -> None:
     with chdir(directory):
         for item in symlinks:
             src = item["src"]
-            for link in item.get("links"):
+            for link in item["links"]:
                 print(f"Creating symlink {src} -> {link}")
                 os.symlink(src, link)


### PR DESCRIPTION


## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Testing
- [x] Ready to be merged
- [ ] Added myself to contributors table

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
