### PR TITLE
Use green for copy

### DIFF
--- a/svg/modern/static/copy.svg
+++ b/svg/modern/static/copy.svg
@@ -1,37 +1,161 @@
-<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_6_91)">
-<g filter="url(#filter0_d_6_91)">
-<path d="M35.0009 121.929L35 121.866V35.0656C35 30.5634 35.4941 26.2374 36.9588 22.5856C38.4976 18.7491 41.482 14.9001 46.5424 13.5038C51.1615 12.2293 55.5209 13.5892 58.7164 15.1797C62.0231 16.8254 65.3089 19.3182 68.4883 22.2243L133.059 79.4939L133.089 79.5205C137.869 83.7999 139.834 90.4283 139.991 95.7184C140.133 100.54 138.713 109.139 130.632 112.523C127.449 113.855 123.562 114.01 120.953 114.074C119.434 114.112 117.794 114.113 116.183 114.114L116.143 114.114C114.484 114.116 112.808 114.117 111.076 114.15C103.993 114.283 97.0871 114.955 91.4127 117.517C85.7762 120.061 80.8047 124.776 76.0424 130.035C75.1857 130.981 74.2053 132.095 73.2184 133.216C71.8633 134.755 70.4942 136.311 69.4098 137.472C67.5723 139.44 64.7955 142.29 61.4966 143.779C57.2016 145.718 52.9555 145.076 49.774 143.731C46.6878 142.426 44.1291 140.304 42.1807 138.186C38.5166 134.202 35.0901 128.058 35.0009 121.929Z" fill="#0000FF"/>
-</g>
-<path d="M43 34.3679C43 18.3085 50.4808 17.3995 62.2068 28.0048L127.935 85.5762C132.894 89.9603 133.798 101.636 127.935 104.06C122.071 106.484 102.841 102.476 87.8191 109.173C72.7973 115.869 63.4668 132.844 57.3905 135.553C51.3142 138.262 43.0966 128.045 43 121.493L43 34.3679Z" fill="#00FF00"/>
-<g filter="url(#filter1_d_6_91)">
-<path d="M150 130C150 158.719 126.719 182 98 182C69.2812 182 46 158.719 46 130C46 101.281 69.2812 78 98 78C126.719 78 150 101.281 150 130Z" fill="#0000FF"/>
-<path d="M142 130C142 154.301 122.301 174 98 174C73.6995 174 54 154.301 54 130C54 105.699 73.6995 86 98 86C122.301 86 142 105.699 142 130Z" fill="#179DD8"/>
-<path d="M121.318 125.091H74.6818C72.6495 125.091 71 126.74 71 128.773V131.227C71 133.26 72.6495 134.909 74.6818 134.909H121.318C123.351 134.909 125 133.26 125 131.227V128.773C125 126.74 123.351 125.091 121.318 125.091Z" fill="white"/>
-<path d="M93.091 106.682V153.318C93.091 155.351 94.7404 157 96.7728 157H99.2272C101.26 157 102.909 155.351 102.909 153.318V106.682C102.909 104.649 101.26 103 99.2272 103H96.7728C94.7404 103 93.091 104.649 93.091 106.682Z" fill="white"/>
-</g>
-</g>
-<defs>
-<filter id="filter0_d_6_91" x="30" y="12" width="115" height="142" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="4"/>
-<feGaussianBlur stdDeviation="2.5"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_6_91"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_6_91" result="shape"/>
-</filter>
-<filter id="filter1_d_6_91" x="42" y="78" width="112" height="112" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="4"/>
-<feGaussianBlur stdDeviation="2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_6_91"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_6_91" result="shape"/>
-</filter>
-<clipPath id="clip0_6_91">
-<rect width="200" height="200" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="200"
+   height="200"
+   viewBox="0 0 200 200"
+   fill="none"
+   version="1.1"
+   id="svg55"
+   sodipodi:docname="copy.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4.355"
+     inkscape:cx="98.392652"
+     inkscape:cy="100.11481"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg55" />
+  <g
+     clip-path="url(#clip0_6_91)"
+     id="g18">
+    <g
+       filter="url(#filter0_d_6_91)"
+       id="g4">
+      <path
+         d="M35.0009 121.929L35 121.866V35.0656C35 30.5634 35.4941 26.2374 36.9588 22.5856C38.4976 18.7491 41.482 14.9001 46.5424 13.5038C51.1615 12.2293 55.5209 13.5892 58.7164 15.1797C62.0231 16.8254 65.3089 19.3182 68.4883 22.2243L133.059 79.4939L133.089 79.5205C137.869 83.7999 139.834 90.4283 139.991 95.7184C140.133 100.54 138.713 109.139 130.632 112.523C127.449 113.855 123.562 114.01 120.953 114.074C119.434 114.112 117.794 114.113 116.183 114.114L116.143 114.114C114.484 114.116 112.808 114.117 111.076 114.15C103.993 114.283 97.0871 114.955 91.4127 117.517C85.7762 120.061 80.8047 124.776 76.0424 130.035C75.1857 130.981 74.2053 132.095 73.2184 133.216C71.8633 134.755 70.4942 136.311 69.4098 137.472C67.5723 139.44 64.7955 142.29 61.4966 143.779C57.2016 145.718 52.9555 145.076 49.774 143.731C46.6878 142.426 44.1291 140.304 42.1807 138.186C38.5166 134.202 35.0901 128.058 35.0009 121.929Z"
+         fill="#0000FF"
+         id="path2" />
+    </g>
+    <path
+       d="M43 34.3679C43 18.3085 50.4808 17.3995 62.2068 28.0048L127.935 85.5762C132.894 89.9603 133.798 101.636 127.935 104.06C122.071 106.484 102.841 102.476 87.8191 109.173C72.7973 115.869 63.4668 132.844 57.3905 135.553C51.3142 138.262 43.0966 128.045 43 121.493L43 34.3679Z"
+       fill="#00FF00"
+       id="path6" />
+    <g
+       filter="url(#filter1_d_6_91)"
+       id="g16">
+      <path
+         d="M150 130C150 158.719 126.719 182 98 182C69.2812 182 46 158.719 46 130C46 101.281 69.2812 78 98 78C126.719 78 150 101.281 150 130Z"
+         fill="#0000FF"
+         id="path8" />
+      <path
+         d="M142 130C142 154.301 122.301 174 98 174C73.6995 174 54 154.301 54 130C54 105.699 73.6995 86 98 86C122.301 86 142 105.699 142 130Z"
+         fill="#179DD8"
+         id="path10"
+         style="fill:#06b231;fill-opacity:1" />
+      <path
+         d="M121.318 125.091H74.6818C72.6495 125.091 71 126.74 71 128.773V131.227C71 133.26 72.6495 134.909 74.6818 134.909H121.318C123.351 134.909 125 133.26 125 131.227V128.773C125 126.74 123.351 125.091 121.318 125.091Z"
+         fill="white"
+         id="path12" />
+      <path
+         d="M93.091 106.682V153.318C93.091 155.351 94.7404 157 96.7728 157H99.2272C101.26 157 102.909 155.351 102.909 153.318V106.682C102.909 104.649 101.26 103 99.2272 103H96.7728C94.7404 103 93.091 104.649 93.091 106.682Z"
+         fill="white"
+         id="path14" />
+    </g>
+  </g>
+  <defs
+     id="defs53">
+    <filter
+       id="filter0_d_6_91"
+       x="30"
+       y="12"
+       width="115"
+       height="142"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood20" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         result="hardAlpha"
+         id="feColorMatrix22" />
+      <feOffset
+         dy="4"
+         id="feOffset24" />
+      <feGaussianBlur
+         stdDeviation="2.5"
+         id="feGaussianBlur26" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix28" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow_6_91"
+         id="feBlend30" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow_6_91"
+         result="shape"
+         id="feBlend32" />
+    </filter>
+    <filter
+       id="filter1_d_6_91"
+       x="42"
+       y="78"
+       width="112"
+       height="112"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood35" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         result="hardAlpha"
+         id="feColorMatrix37" />
+      <feOffset
+         dy="4"
+         id="feOffset39" />
+      <feGaussianBlur
+         stdDeviation="2"
+         id="feGaussianBlur41" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix43" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow_6_91"
+         id="feBlend45" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow_6_91"
+         result="shape"
+         id="feBlend47" />
+    </filter>
+    <clipPath
+       id="clip0_6_91">
+      <rect
+         width="200"
+         height="200"
+         fill="white"
+         id="rect50" />
+    </clipPath>
+  </defs>
 </svg>

--- a/svg/original/static/copy.svg
+++ b/svg/original/static/copy.svg
@@ -1,37 +1,163 @@
-<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_80_868)">
-<g filter="url(#filter0_d_80_868)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M45 2C45 2 98.5 49.5 129 85.5C136.249 94.0558 144.076 104.226 145.5 109C151.268 128.332 108.307 92.1269 86.3664 100.122C65.929 107.569 58.2002 159.078 48 140.5C45.2878 135.56 45 125 45 125V2Z" fill="#0000FF"/>
-</g>
-<path d="M53 21V121L87 105L124 91.0961L53 21Z" fill="#00FF00"/>
-<g filter="url(#filter1_d_80_868)">
-<path d="M150 130C150 158.719 126.719 182 98 182C69.2812 182 46 158.719 46 130C46 101.281 69.2812 78 98 78C126.719 78 150 101.281 150 130Z" fill="#0000FF"/>
-<path d="M142 130C142 154.301 122.301 174 98 174C73.6995 174 54 154.301 54 130C54 105.699 73.6995 86 98 86C122.301 86 142 105.699 142 130Z" fill="#179DD8"/>
-<path d="M121.318 125.091H74.6818C72.6495 125.091 71 126.74 71 128.773V131.227C71 133.26 72.6495 134.909 74.6818 134.909H121.318C123.351 134.909 125 133.26 125 131.227V128.773C125 126.74 123.351 125.091 121.318 125.091Z" fill="white"/>
-<path d="M93.091 106.682V153.318C93.091 155.351 94.7404 157 96.7728 157H99.2272C101.26 157 102.909 155.351 102.909 153.318V106.682C102.909 104.649 101.26 103 99.2272 103H96.7728C94.7404 103 93.091 104.649 93.091 106.682Z" fill="white"/>
-</g>
-</g>
-<defs>
-<filter id="filter0_d_80_868" x="40" y="1" width="111.027" height="152.515" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="4"/>
-<feGaussianBlur stdDeviation="2.5"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_80_868"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_80_868" result="shape"/>
-</filter>
-<filter id="filter1_d_80_868" x="42" y="78" width="112" height="112" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="4"/>
-<feGaussianBlur stdDeviation="2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_80_868"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_80_868" result="shape"/>
-</filter>
-<clipPath id="clip0_80_868">
-<rect width="200" height="200" fill="white"/>
-</clipPath>
-</defs>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="200"
+   height="200"
+   viewBox="0 0 200 200"
+   fill="none"
+   version="1.1"
+   id="svg55"
+   sodipodi:docname="copy.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4.355"
+     inkscape:cx="98.392652"
+     inkscape:cy="100.11481"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg55" />
+  <g
+     clip-path="url(#clip0_80_868)"
+     id="g18">
+    <g
+       filter="url(#filter0_d_80_868)"
+       id="g4">
+      <path
+         fill-rule="evenodd"
+         clip-rule="evenodd"
+         d="M45 2C45 2 98.5 49.5 129 85.5C136.249 94.0558 144.076 104.226 145.5 109C151.268 128.332 108.307 92.1269 86.3664 100.122C65.929 107.569 58.2002 159.078 48 140.5C45.2878 135.56 45 125 45 125V2Z"
+         fill="#0000FF"
+         id="path2" />
+    </g>
+    <path
+       d="M53 21V121L87 105L124 91.0961L53 21Z"
+       fill="#00FF00"
+       id="path6" />
+    <g
+       filter="url(#filter1_d_80_868)"
+       id="g16">
+      <path
+         d="M150 130C150 158.719 126.719 182 98 182C69.2812 182 46 158.719 46 130C46 101.281 69.2812 78 98 78C126.719 78 150 101.281 150 130Z"
+         fill="#0000FF"
+         id="path8" />
+      <path
+         d="M142 130C142 154.301 122.301 174 98 174C73.6995 174 54 154.301 54 130C54 105.699 73.6995 86 98 86C122.301 86 142 105.699 142 130Z"
+         fill="#179DD8"
+         id="path10"
+         style="fill:#06b231;fill-opacity:1" />
+      <path
+         d="M121.318 125.091H74.6818C72.6495 125.091 71 126.74 71 128.773V131.227C71 133.26 72.6495 134.909 74.6818 134.909H121.318C123.351 134.909 125 133.26 125 131.227V128.773C125 126.74 123.351 125.091 121.318 125.091Z"
+         fill="white"
+         id="path12" />
+      <path
+         d="M93.091 106.682V153.318C93.091 155.351 94.7404 157 96.7728 157H99.2272C101.26 157 102.909 155.351 102.909 153.318V106.682C102.909 104.649 101.26 103 99.2272 103H96.7728C94.7404 103 93.091 104.649 93.091 106.682Z"
+         fill="white"
+         id="path14" />
+    </g>
+  </g>
+  <defs
+     id="defs53">
+    <filter
+       id="filter0_d_80_868"
+       x="40"
+       y="1"
+       width="111.027"
+       height="152.515"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood20" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         result="hardAlpha"
+         id="feColorMatrix22" />
+      <feOffset
+         dy="4"
+         id="feOffset24" />
+      <feGaussianBlur
+         stdDeviation="2.5"
+         id="feGaussianBlur26" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix28" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow_80_868"
+         id="feBlend30" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow_80_868"
+         result="shape"
+         id="feBlend32" />
+    </filter>
+    <filter
+       id="filter1_d_80_868"
+       x="42"
+       y="78"
+       width="112"
+       height="112"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood35" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         result="hardAlpha"
+         id="feColorMatrix37" />
+      <feOffset
+         dy="4"
+         id="feOffset39" />
+      <feGaussianBlur
+         stdDeviation="2"
+         id="feGaussianBlur41" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix43" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow_80_868"
+         id="feBlend45" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow_80_868"
+         result="shape"
+         id="feBlend47" />
+    </filter>
+    <clipPath
+       id="clip0_80_868">
+      <rect
+         width="200"
+         height="200"
+         fill="white"
+         id="rect50" />
+    </clipPath>
+  </defs>
 </svg>

--- a/svg/original/static/dnd-copy.svg
+++ b/svg/original/static/dnd-copy.svg
@@ -1,33 +1,147 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" fill="none">
-  <g filter="url(#filter0_d)">
-    <path d="M61.3979 46.5234C64.9821 41.6763 70.5721 38.3194 76.8087 37.9382C81.3907 37.6525 85.8189 39.0059 89.4925 41.4751C92.913 38.3611 97.328 36.3363 102.09 36.0394C108.471 35.6334 114.124 38.4105 117.947 42.2156C119.709 43.969 121.256 46.1154 122.372 48.547C122.969 48.4553 123.571 48.3903 124.179 48.3531C131.658 47.8322 137.457 51.6501 140.958 56.2561C144.347 60.7143 146.044 66.3506 146.079 71.6996L146.079 71.7035L146.158 83.5812C146.172 85.6296 146.22 87.8334 146.272 90.1765C146.649 107.424 147.193 132.228 135.369 158.31L132.718 164.159L62.666 164.405L62.6483 164.405C56.8286 164.436 51.6485 161.589 47.8569 158.812C43.8019 155.843 39.896 151.887 36.3871 147.594C29.405 139.051 23.0028 127.947 19.6956 117.477C16.358 106.912 18.2257 98.1713 22.8715 91.3037C26.5576 85.8549 31.8812 81.9245 35.1511 79.5104L35.2736 79.4199L33.6412 69.2626C32.6054 63.1665 34.6141 57.4165 37.8225 53.2573C41.0451 49.0796 46.1162 45.6765 52.2877 45.1243L52.3713 45.1168L52.4551 45.1107C55.5528 44.8859 58.5995 45.4079 61.3979 46.5234Z" fill="#0000FF"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="200"
+   height="200"
+   viewBox="0 0 200 200"
+   fill="none"
+   version="1.1"
+   id="svg50"
+   sodipodi:docname="dnd-copy.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview52"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4.355"
+     inkscape:cx="98.392652"
+     inkscape:cy="100.11481"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg50" />
+  <g
+     filter="url(#filter0_d)"
+     id="g4">
+    <path
+       d="M61.3979 46.5234C64.9821 41.6763 70.5721 38.3194 76.8087 37.9382C81.3907 37.6525 85.8189 39.0059 89.4925 41.4751C92.913 38.3611 97.328 36.3363 102.09 36.0394C108.471 35.6334 114.124 38.4105 117.947 42.2156C119.709 43.969 121.256 46.1154 122.372 48.547C122.969 48.4553 123.571 48.3903 124.179 48.3531C131.658 47.8322 137.457 51.6501 140.958 56.2561C144.347 60.7143 146.044 66.3506 146.079 71.6996L146.079 71.7035L146.158 83.5812C146.172 85.6296 146.22 87.8334 146.272 90.1765C146.649 107.424 147.193 132.228 135.369 158.31L132.718 164.159L62.666 164.405L62.6483 164.405C56.8286 164.436 51.6485 161.589 47.8569 158.812C43.8019 155.843 39.896 151.887 36.3871 147.594C29.405 139.051 23.0028 127.947 19.6956 117.477C16.358 106.912 18.2257 98.1713 22.8715 91.3037C26.5576 85.8549 31.8812 81.9245 35.1511 79.5104L35.2736 79.4199L33.6412 69.2626C32.6054 63.1665 34.6141 57.4165 37.8225 53.2573C41.0451 49.0796 46.1162 45.6765 52.2877 45.1243L52.3713 45.1168L52.4551 45.1107C55.5528 44.8859 58.5995 45.4079 61.3979 46.5234Z"
+       fill="#0000FF"
+       id="path2" />
   </g>
-  <path d="M77.4256 47.9186C71.7685 48.2606 66.9389 53.7084 67.303 59.3381L68.0005 69.3174C68.1775 71.854 65.8019 72.3842 65.526 70.4367L64.6517 64.2643C63.8782 58.946 58.5637 54.6932 53.1794 55.0839C47.2553 55.614 42.4921 61.7891 43.5067 67.6231L47.3055 91.2607C47.3422 92.1705 47.081 96.8587 47.081 96.8587L42.1321 86.7825C34.9031 92.2021 24.3884 99.1325 29.2317 114.465C34.9639 132.61 52.1059 154.472 62.6023 154.404L126.262 154.181C138.579 127.009 136.28 101.63 136.159 83.6479L136.079 71.7662C136.036 64.9578 131.653 57.8276 124.832 58.3314C120.218 58.5941 115.986 62.1363 114.934 66.616L113.664 73.3478C113.286 75.3552 112.614 74.5295 112.765 72.9002L114.192 57.4385C114.586 51.3607 108.825 45.6264 102.719 46.0191C97.4413 46.3444 92.8075 51.0594 92.5967 56.319L91.3948 67.0785C91.114 69.592 89.5234 69.654 89.3703 66.8547L88.8981 58.2193C88.6699 52.5117 83.1526 47.5577 77.4256 47.9186Z" fill="#00FF00"/>
-  <g filter="url(#filter1_d)">
-    <path d="M190 138C190 166.719 166.719 190 138 190C109.281 190 86 166.719 86 138C86 109.281 109.281 86 138 86C166.719 86 190 109.281 190 138Z" fill="#0000FF"/>
-    <path d="M182 138C182 162.301 162.301 182 138 182C113.699 182 94 162.301 94 138C94 113.699 113.699 94 138 94C162.301 94 182 113.699 182 138Z" fill="#179DD8"/>
-    <path d="M161.318 133.091H114.682C112.649 133.091 111 134.74 111 136.773V139.227C111 141.26 112.649 142.909 114.682 142.909H161.318C163.351 142.909 165 141.26 165 139.227V136.773C165 134.74 163.351 133.091 161.318 133.091Z" fill="white"/>
-    <path d="M133.091 114.682V161.318C133.091 163.351 134.74 165 136.773 165H139.227C141.26 165 142.909 163.351 142.909 161.318V114.682C142.909 112.649 141.26 111 139.227 111H136.773C134.74 111 133.091 112.649 133.091 114.682Z" fill="white"/>
+  <path
+     d="M77.4256 47.9186C71.7685 48.2606 66.9389 53.7084 67.303 59.3381L68.0005 69.3174C68.1775 71.854 65.8019 72.3842 65.526 70.4367L64.6517 64.2643C63.8782 58.946 58.5637 54.6932 53.1794 55.0839C47.2553 55.614 42.4921 61.7891 43.5067 67.6231L47.3055 91.2607C47.3422 92.1705 47.081 96.8587 47.081 96.8587L42.1321 86.7825C34.9031 92.2021 24.3884 99.1325 29.2317 114.465C34.9639 132.61 52.1059 154.472 62.6023 154.404L126.262 154.181C138.579 127.009 136.28 101.63 136.159 83.6479L136.079 71.7662C136.036 64.9578 131.653 57.8276 124.832 58.3314C120.218 58.5941 115.986 62.1363 114.934 66.616L113.664 73.3478C113.286 75.3552 112.614 74.5295 112.765 72.9002L114.192 57.4385C114.586 51.3607 108.825 45.6264 102.719 46.0191C97.4413 46.3444 92.8075 51.0594 92.5967 56.319L91.3948 67.0785C91.114 69.592 89.5234 69.654 89.3703 66.8547L88.8981 58.2193C88.6699 52.5117 83.1526 47.5577 77.4256 47.9186Z"
+     fill="#00FF00"
+     id="path6" />
+  <g
+     filter="url(#filter1_d)"
+     id="g16">
+    <path
+       d="M190 138C190 166.719 166.719 190 138 190C109.281 190 86 166.719 86 138C86 109.281 109.281 86 138 86C166.719 86 190 109.281 190 138Z"
+       fill="#0000FF"
+       id="path8" />
+    <path
+       d="M182 138C182 162.301 162.301 182 138 182C113.699 182 94 162.301 94 138C94 113.699 113.699 94 138 94C162.301 94 182 113.699 182 138Z"
+       fill="#179DD8"
+       id="path10"
+       style="fill:#06b231;fill-opacity:1" />
+    <path
+       d="M161.318 133.091H114.682C112.649 133.091 111 134.74 111 136.773V139.227C111 141.26 112.649 142.909 114.682 142.909H161.318C163.351 142.909 165 141.26 165 139.227V136.773C165 134.74 163.351 133.091 161.318 133.091Z"
+       fill="white"
+       id="path12" />
+    <path
+       d="M133.091 114.682V161.318C133.091 163.351 134.74 165 136.773 165H139.227C141.26 165 142.909 163.351 142.909 161.318V114.682C142.909 112.649 141.26 111 139.227 111H136.773C134.74 111 133.091 112.649 133.091 114.682Z"
+       fill="white"
+       id="path14" />
   </g>
-  <defs>
-    <filter id="filter0_d" x="13" y="35" width="138.419" height="138.405" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
-      <feOffset dy="4"/>
-      <feGaussianBlur stdDeviation="2.5"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  <defs
+     id="defs48">
+    <filter
+       id="filter0_d"
+       x="13"
+       y="35"
+       width="138.419"
+       height="138.405"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood18" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         id="feColorMatrix20" />
+      <feOffset
+         dy="4"
+         id="feOffset22" />
+      <feGaussianBlur
+         stdDeviation="2.5"
+         id="feGaussianBlur24" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix26" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow"
+         id="feBlend28" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow"
+         result="shape"
+         id="feBlend30" />
     </filter>
-    <filter id="filter1_d" x="82" y="86" width="112" height="112" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
-      <feOffset dy="4"/>
-      <feGaussianBlur stdDeviation="2"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    <filter
+       id="filter1_d"
+       x="82"
+       y="86"
+       width="112"
+       height="112"
+       filterUnits="userSpaceOnUse"
+       color-interpolation-filters="sRGB">
+      <feFlood
+         flood-opacity="0"
+         result="BackgroundImageFix"
+         id="feFlood33" />
+      <feColorMatrix
+         in="SourceAlpha"
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+         id="feColorMatrix35" />
+      <feOffset
+         dy="4"
+         id="feOffset37" />
+      <feGaussianBlur
+         stdDeviation="2"
+         id="feGaussianBlur39" />
+      <feColorMatrix
+         type="matrix"
+         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+         id="feColorMatrix41" />
+      <feBlend
+         mode="normal"
+         in2="BackgroundImageFix"
+         result="effect1_dropShadow"
+         id="feBlend43" />
+      <feBlend
+         mode="normal"
+         in="SourceGraphic"
+         in2="effect1_dropShadow"
+         result="shape"
+         id="feBlend45" />
     </filter>
   </defs>
 </svg>


### PR DESCRIPTION
Purple and blue are too close to each other.
Green is commonly associated with "Adding/copying".

With links moving from green to grey, we can now give green to copying and blue to moving.

This commit changes the color of copying to green.