### PR TITLE
Document "attrs" dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Run the `uninstall.bat` script packed with the `.zip` archive
 
 - Python version 3.7 or higher
 - [clickgen](https://github.com/ful1e5/clickgen)>=2.1.2 (`pip install clickgen`)
+- [attrs](https://github.com/python-attrs/attrs)>=22.2.0 (`pip install attrs`)
 - [yarn](https://github.com/yarnpkg/yarn)
 
 ### Quick start


### PR DESCRIPTION
I wasn't able to get this building after a fresh clone without also installing the `attrs` package, which `clickgen` attempts to load.

I'm not familiar with the Python ecosystem, so I'm not sure if that's a problem in clickgen, or if it's expected.

This adds `attrs` to the README as a build prerequisite, so other people will not run into the error I did.

I said that 22.2.0 is the minimum version, because that is the current version and it worked, but maybe a lower version would work instead. I'm not sure.