### PR TITLE
feat: use 'xz' for better compression

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -40,12 +40,12 @@ cd themes
 
 for key in "${!names[@]}";
 do
-    tar -czvf "../bin/${key}.tar.gz" "${key}" &
+    tar -cJvf "../bin/${key}.tar.xz" "${key}" &
     PID=$!
     wait $PID
 done
 
-tar -czvf "../bin/Bibata.tar.gz"  --exclude="*-Windows" . &
+tar -cJvf "../bin/Bibata.tar.xz"  --exclude="*-Windows" . &
 PID=$!
 wait $PID
 


### PR DESCRIPTION
Using `xz` compression tool release package size can be as small as _~4mb_ compare to `gzip` compression which is **~75%** smaller.