### PR TITLE
Change installation guide to use .local/share/icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,20 +159,20 @@ sudo dnf install bibata-cursor-theme
 
 ## Installing Bibata Cursor
 
-#### Linux/X11
+#### Linux X11/Wayland
 
 **Installation:**
 
 ```bash
 tar -xvf Bibata.tar.gz                # extract `Bibata.tar.gz`
-mv Bibata-* ~/.icons/                 # Install to local users
+mv Bibata-* ~/.local/share/icons/                 # Install to local users
 sudo mv Bibata-* /usr/share/icons/    # Install to all users
 ```
 
 **Uninstallation:**
 
 ```bash
-rm ~/.icons/Bibata-*                  # Remove from local users
+rm ~/.local/share/icons/Bibata-*                  # Remove from local users
 sudo rm /usr/share/icons/Bibata-*     # Remove from all users
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ sudo dnf install bibata-cursor-theme
 
 ```bash
 tar -xvf Bibata.tar.gz                # extract `Bibata.tar.gz`
-mv Bibata-* ~/.local/share/icons/                 # Install to local users
+mv Bibata-* ~/.local/share/icons/     # Install to local users
 sudo mv Bibata-* /usr/share/icons/    # Install to all users
 ```
 
 **Uninstallation:**
 
 ```bash
-rm ~/.local/share/icons/Bibata-*                  # Remove from local users
+rm ~/.local/share/icons/Bibata-*      # Remove from local users
 sudo rm /usr/share/icons/Bibata-*     # Remove from all users
 ```
 


### PR DESCRIPTION
XDG Base Directory specification prefers ~/.local/share/icons. And for some flatpak applications on Wayland such as Vesktop and VSCodium, it will not search for icons in ~/.icons. Changing the directory to this will avoid any issues with cursors not being applied to some applications.